### PR TITLE
feat: use `os.availableParallelism` when available

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "devDependencies": {
     "@types/node": "^18.17.4",
     "jest": "^26.6.3",
-    "typescript": "^4.1.3"
+    "typescript": "~4.3.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "testEnvironment": "node"
   },
   "devDependencies": {
-    "@types/node": "^14.14.14",
+    "@types/node": "^18.17.4",
     "jest": "^26.6.3",
     "typescript": "^4.1.3"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,12 @@ export class Worker<Args extends any[], Ret = any> {
     options: Options = {}
   ) {
     this.code = genWorkerCode(fn)
-    this.max = options.max || Math.max(1, os.cpus().length - 1)
+    const defaultMax = Math.max(
+      1,
+      // os.availableParallelism is available from Node.js 18.14.0
+      (os.availableParallelism?.() ?? os.cpus().length) - 1
+    )
+    this.max = options.max || defaultMax
     this.pool = []
     this.idlePool = []
     this.queue = []

--- a/yarn.lock
+++ b/yarn.lock
@@ -538,10 +538,15 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/node@*", "@types/node@^14.14.14":
+"@types/node@*":
   version "14.14.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.14.tgz#f7fd5f3cc8521301119f63910f0fb965c7d761ae"
   integrity sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==
+
+"@types/node@^18.17.4":
+  version "18.17.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.17.4.tgz#bf8ae9875528929cc9930dc3f066cd0481fe1231"
+  integrity sha512-ATL4WLgr7/W40+Sp1WnNTSKbgVn6Pvhc/2RHAdt8fl6NsQyp4oPCi2eKcGOvA494bwf1K/W6nGgZ9TwDqvpjdw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3368,10 +3368,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@~4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Now Node.js recommends using `os.availableParallelism` instead of `os.cpus().length` for this purpose.
https://nodejs.org/api/os.html#oscpus:~:text=os.cpus().length%20should%20not%20be%20used%20to%20calculate%20the%20amount%20of%20parallelism%20available%20to%20an%20application.%20Use%20os.availableParallelism()%20for%20this%20purpose.

This PR makes the default value to use that when it's available. (Node.js 18.14.0+, 19.4.0+)
https://nodejs.org/api/os.html#osavailableparallelism

I also updated TypeScript as the type check failed on my machine.

I tested this change by running `yarn test` on Node.js 18.17.1 (Windows) and on Node.js 18.12.1 (WSL).
